### PR TITLE
Adding deps.conf support

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -3,22 +3,23 @@
 # every argument other than build=
 # can be left empty if desired
 #
-#Standard Options
+# Standard Options
 build=nuild.nim
 cc=clang
 ssl=false
 release=true
 opt=speed
-force=true
+force=false
+deps=true
 app=console
 install=/usr/bin
-#Special Options
+# Special Options
 termux=false
-#Debug Options
+# Debug Options
 stack=false
 line=false
 debugger=false
-#Runtime Checks
+# Runtime Checks
 objCheck=false
 fieldCheck=false
 rangeCheck=false

--- a/deps.conf
+++ b/deps.conf
@@ -1,1 +1,8 @@
+# Dependencies conf gor nuild builds
+#
+# just as you would name a package in nimble you 
+# will name it here as we used nimble as a backend
+#
+#
 fab
+


### PR DESCRIPTION
This addition requires nimble as a back-end which is assumed to be installed on the device.
